### PR TITLE
Change regex and handle edited messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,7 @@ def resolve_args():
         )
 
 
-REDDIT_REGEX = re.compile(r'(?:\b|\B/)r/(\w+)')
+REDDIT_REGEX = re.compile(r'(?:[^/]\b|\B/)r/(\w+)')
 
 REDDIT_URL = 'https://www.reddit.com/r/{}/'
 

--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,7 @@ def resolve_args():
         )
 
 
-REDDIT_REGEX = re.compile(r'\B/r/(\w+)')
+REDDIT_REGEX = re.compile(r'(?:\b|\B/)r/(\w+)')
 
 REDDIT_URL = 'https://www.reddit.com/r/{}/'
 

--- a/bot.py
+++ b/bot.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import re
 
-from telegram.ext import Updater, MessageHandler, CommandHandler, Filters
+from telegram.ext import Updater, MessageHandler, Filters
 
 import config
 

--- a/bot.py
+++ b/bot.py
@@ -44,7 +44,8 @@ if __name__ == '__main__':
 
     print(updater.bot.get_me())
 
-    dispatcher.add_handler(MessageHandler(Filters.all, get_link))
+    dispatcher.add_handler(MessageHandler(Filters.all, get_link,
+                                          edited_updates=True))
 
     updater.start_webhook(
         listen='0.0.0.0', port=config.PORT, url_path=config.BOT_TOKEN)


### PR DESCRIPTION
This new regex matches all the following strings, except number 5.
```
1. r/aww
2. /r/aww
3. ,r/aww
4. ,/r/aww
5. ar/aww
6. a/r/aww
```

I feel it shouldn't match number 6 either, but I couldn't find a decent way to do that. Suggestions are welcome.